### PR TITLE
Fix repository clone URL in README

### DIFF
--- a/meepzorp/README.md
+++ b/meepzorp/README.md
@@ -61,7 +61,7 @@ Connects to data storage for agent consumption.
 
 ```bash
 # Clone
-git clone https://github.com/zk-xyz/meepzorp_test.git
+git clone https://github.com/zk-xyz/meepzorp.git
 cd meepzorp
 
 # Create your env file *in the repo root*


### PR DESCRIPTION
## Summary
- update the clone command in `meepzorp/README.md`

## Testing
- `pytest meepzorp/orchestration/tests -q` *(fails: `pytest` not installed)*