### PR TITLE
Update default port in docs

### DIFF
--- a/docs/setup/port-configuration.md
+++ b/docs/setup/port-configuration.md
@@ -45,10 +45,10 @@ When setting up a new project or agent, follow these steps to ensure correct por
 3. **Agent Dockerfile Setup**
    - Create a startup script to handle environment variable substitution:
      ```dockerfile
-     RUN echo '#!/bin/sh\nuvicorn src.main:app --host 0.0.0.0 --port ${AGENT_PORT:-default}' > /app/start.sh && \
+     RUN echo '#!/bin/sh\nuvicorn src.main:app --host 0.0.0.0 --port ${AGENT_PORT:-8000}' > /app/start.sh && \
          chmod +x /app/start.sh
      
-     EXPOSE ${AGENT_PORT:-default}
+     EXPOSE ${AGENT_PORT:-8000}
      
      CMD ["/app/start.sh"]
      ```


### PR DESCRIPTION
## Summary
- set default `${AGENT_PORT}` to 8000 in `port-configuration.md`

## Testing
- `pytest -q` *(fails: command not found)*