### PR TITLE
Fix target type lookup in graph suggestions

### DIFF
--- a/agents/personal/src/capabilities/graph_suggestions.py
+++ b/agents/personal/src/capabilities/graph_suggestions.py
@@ -5,6 +5,7 @@ from typing import List, Dict, Any, Optional, Tuple
 from pydantic import BaseModel, Field
 from ..db import KnowledgeDB
 import logging
+import requests
 import json
 import re
 from difflib import SequenceMatcher
@@ -236,7 +237,7 @@ class SuggestConnectionsCapability:
         """Infer the most likely relationship type between entities."""
         # This is a simplified version - in practice, you'd use more sophisticated logic
         source_type = source.get("type", "").lower()
-        target_type = source.get("type", "").lower()
+        target_type = target.get("type", "").lower()
         
         # Define some basic relationship type rules
         type_rules = {


### PR DESCRIPTION
## Summary
- fix relationship target type inference
- include `requests` import for personal graph suggestions
- (tests unavailable due to missing pytest)

## Testing
- `python -m pytest agents/personal` *(fails: No module named pytest)*