### PR TITLE
Fix knowledge DB updates and add tests

### DIFF
--- a/agents/personal/src/db.py
+++ b/agents/personal/src/db.py
@@ -9,26 +9,26 @@ from loguru import logger
 
 class KnowledgeDB:
     """Database operations for knowledge storage."""
-    
+
     def __init__(self):
         self.supabase_url = os.getenv("SUPABASE_URL")
         self.supabase_key = os.getenv("SUPABASE_KEY")
-        
+
         if not self.supabase_url:
             raise ValueError("SUPABASE_URL environment variable must be set")
         if not self.supabase_key:
             raise ValueError("SUPABASE_KEY environment variable must be set")
-            
+
         self.headers = {
             "apikey": self.supabase_key,
             "Authorization": f"Bearer {self.supabase_key}",
             "Content-Type": "application/json",
             "Prefer": "return=representation"
         }
-    
+
     async def store_knowledge(self, content: str, tags: List[str] = None, embedding: Optional[List[float]] = None) -> Dict[str, Any]:
         """Store a piece of knowledge.
-        
+
         Args:
             content: The text content to store
             tags: Optional list of tags for categorization
@@ -39,34 +39,34 @@ class KnowledgeDB:
                 "content": content,
                 "tags": {"tags": tags or []}  # Store tags in the correct format
             }
-            
+
             if embedding:
                 data["embedding"] = embedding
-            
+
             logger.debug(f"Storing knowledge with data: {data}")
             response = requests.post(
                 f"{self.supabase_url}/rest/v1/knowledge",
                 headers=self.headers,
                 json=data
             )
-            
+
             if response.status_code != 201:
                 raise Exception(f"Failed to store knowledge: {response.text}")
-                
+
             result = response.json()
             logger.info(f"Stored knowledge with ID {result['id']}")
-            
+
             # Parse tags back to list for consistent return format
             result["tags"] = result["tags"].get("tags", []) if result.get("tags") else []
             return result
-            
+
         except Exception as e:
             logger.error(f"Error storing knowledge: {str(e)}")
             raise
-    
+
     async def query_knowledge(self, query: str = None, tags: List[str] = None, embedding: List[float] = None, limit: int = 10) -> List[Dict[str, Any]]:
         """Query knowledge items.
-        
+
         Args:
             query: Optional text query to search in content
             tags: Optional list of tags to filter by
@@ -78,51 +78,51 @@ class KnowledgeDB:
             params = {}
             if limit:
                 params["limit"] = str(limit)
-            
+
             # Build filter conditions
             filters = []
-            
+
             if tags:
                 # Convert tags to JSON string for comparison
                 tags_json = json.dumps(sorted(tags))
                 filters.append(f"tags->>'tags'=eq.{tags_json}")
-            
+
             if query:
                 filters.append(f"content.ilike.*{query}*")
-            
+
             if embedding:
                 # If we have an embedding, use vector similarity search
                 filters.append(f"embedding <-> '{embedding}'::vector < 0.3")
                 # Order by vector distance using the provided embedding
                 params["order"] = f"embedding <-> '{embedding}'::vector"
-            
+
             if filters:
                 # Combine filters using the PostgREST "and" operator
                 # Example result: "(filter1,filter2)"
                 params["and"] = "(" + ",".join(filters) + ")"
-            
+
             # Make the request
             response = requests.get(
                 f"{self.supabase_url}/rest/v1/knowledge",
                 headers=self.headers,
                 params=params
             )
-            
+
             if response.status_code != 200:
                 raise Exception(f"Failed to query knowledge: {response.text}")
-            
+
             # Parse results
             items = response.json()
             for item in items:
                 item["tags"] = json.loads(item["tags"])
-            
+
             logger.info(f"Found {len(items)} knowledge items")
             return items
-            
+
         except Exception as e:
             logger.error(f"Error querying knowledge: {str(e)}")
             raise
-    
+
     async def delete_knowledge(self, knowledge_id: str) -> None:
         """Delete a knowledge item by ID."""
         try:
@@ -131,19 +131,19 @@ class KnowledgeDB:
                 headers=self.headers,
                 params={"id": f"eq.{knowledge_id}"}
             )
-            
+
             if response.status_code != 204:
                 raise Exception(f"Failed to delete knowledge: {response.text}")
-                
+
             logger.info(f"Deleted knowledge with ID {knowledge_id}")
-            
+
         except Exception as e:
             logger.error(f"Error deleting knowledge: {str(e)}")
             raise
-    
+
     async def update_knowledge(self, knowledge_id: str, content: Optional[str] = None, tags: Optional[List[str]] = None, embedding: Optional[List[float]] = None) -> Dict[str, Any]:
         """Update a knowledge item.
-        
+
         Args:
             knowledge_id: ID of the knowledge item to update
             content: Optional new content
@@ -156,30 +156,35 @@ class KnowledgeDB:
             if content is not None:
                 data["content"] = content
             if tags is not None:
-                data["tags"] = json.dumps(tags)
+                # Store tags in the same object format as during creation
+                data["tags"] = {"tags": tags}
             if embedding is not None:
                 data["embedding"] = embedding
-            
+
             if not data:
                 raise ValueError("No update data provided")
-            
+
             response = requests.patch(
                 f"{self.supabase_url}/rest/v1/knowledge",
                 headers=self.headers,
                 params={"id": f"eq.{knowledge_id}"},
                 json=data
             )
-            
+
             if response.status_code != 200:
                 raise Exception(f"Failed to update knowledge: {response.text}")
-                
+
             result = response.json()[0]
             logger.info(f"Updated knowledge with ID {knowledge_id}")
-            
-            # Parse tags back to list
-            result["tags"] = json.loads(result["tags"])
+
+            # Parse tags back to list for consistent return
+            tags_val = result.get("tags")
+            if isinstance(tags_val, dict):
+                result["tags"] = tags_val.get("tags", [])
+            else:
+                result["tags"] = json.loads(tags_val) if tags_val else []
             return result
-            
+
         except Exception as e:
             logger.error(f"Error updating knowledge: {str(e)}")
-            raise 
+            raise

--- a/agents/personal/tests/__init__.py
+++ b/agents/personal/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the personal agent database layer."""

--- a/agents/personal/tests/test_db.py
+++ b/agents/personal/tests/test_db.py
@@ -1,0 +1,49 @@
+import os
+import pytest
+from agents.personal.src.db import KnowledgeDB
+
+class MockResponse:
+    def __init__(self, status_code: int, json_data=None, text=""):
+        self.status_code = status_code
+        self._json = json_data
+        self.text = text
+
+    def json(self):
+        return self._json
+
+@pytest.fixture
+def db(monkeypatch):
+    monkeypatch.setenv("SUPABASE_URL", "http://localhost")
+    monkeypatch.setenv("SUPABASE_KEY", "test-key")
+    return KnowledgeDB()
+
+@pytest.mark.asyncio
+async def test_store_knowledge(mocker, db):
+    post_resp = MockResponse(201, {"id": "1", "content": "hello", "tags": {"tags": ["tag1"]}})
+    mocker.patch("requests.post", return_value=post_resp)
+    result = await db.store_knowledge("hello", ["tag1"], [0.1])
+    assert result["id"] == "1"
+    assert result["tags"] == ["tag1"]
+
+@pytest.mark.asyncio
+async def test_query_knowledge(mocker, db):
+    get_resp = MockResponse(200, [{"id": "1", "content": "hello", "tags": "[\"tag1\"]"}])
+    mocker.patch("requests.get", return_value=get_resp)
+    items = await db.query_knowledge(query="hello")
+    assert len(items) == 1
+    assert items[0]["tags"] == ["tag1"]
+
+@pytest.mark.asyncio
+async def test_update_knowledge(mocker, db):
+    patch_resp = MockResponse(200, [{"id": "1", "content": "updated", "tags": {"tags": ["tag2"]}}])
+    mocker.patch("requests.patch", return_value=patch_resp)
+    result = await db.update_knowledge("1", content="updated", tags=["tag2"])
+    assert result["content"] == "updated"
+    assert result["tags"] == ["tag2"]
+
+@pytest.mark.asyncio
+async def test_delete_knowledge(mocker, db):
+    delete_resp = MockResponse(204)
+    mocker.patch("requests.delete", return_value=delete_resp)
+    await db.delete_knowledge("1")
+


### PR DESCRIPTION
## Summary
- handle tag structure correctly when updating knowledge
- return cleaned tags from update calls
- add unit tests for storing, querying, updating and deleting knowledge

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*