### PR TITLE
Fix module imports for package execution

### DIFF
--- a/orchestration/main.py
+++ b/orchestration/main.py
@@ -9,9 +9,9 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from typing import Dict, Any
 
-from registry import AgentRegistryTool, AgentDiscoveryTool
-from router import RouteRequestTool
-from workflows import ExecuteWorkflowTool
+from .registry import AgentRegistryTool, AgentDiscoveryTool
+from .router import RouteRequestTool
+from .workflows import ExecuteWorkflowTool
 
 # Configure logging
 logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))


### PR DESCRIPTION
## Summary
- update imports in `orchestration/main.py` to use package-relative form
- verify service can be started via `python -m meepzorp.orchestration.main`

## Testing
- `python -m meepzorp.orchestration.main`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6835103ddce0832198c1c247783e0712