### PR TITLE
Add ExecuteWorkflowTool bogus ID test

### DIFF
--- a/orchestration/tests/test_orchestration.py
+++ b/orchestration/tests/test_orchestration.py
@@ -146,6 +146,21 @@ async def test_workflow_creation_and_execution(mock_workflow):
     assert execute_result["status"] == "success", f"Workflow execution failed: {execute_result.get('message', 'No error message')}"
     assert "results" in execute_result
 
+
+@pytest.mark.asyncio
+async def test_execute_workflow_invalid_id(mock_workflow):
+    """Ensure executing a non-existent workflow returns an error."""
+    creator = CreateWorkflowTool()
+    create_result = await creator.execute(mock_workflow)
+    assert create_result["status"] == "success"
+
+    executor = ExecuteWorkflowTool()
+    execute_result = await executor.execute({
+        "workflow_id": "bogus_id",
+        "input_variables": {}
+    })
+    assert execute_result["status"] == "error"
+
 @pytest.mark.asyncio
 async def test_error_handling():
     """Test error handling in orchestration components."""


### PR DESCRIPTION
## Summary
- add test for executing workflow with bogus id

## Testing
- `pytest orchestration/tests/test_orchestration.py::test_execute_workflow_invalid_id -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_684084809c5c8321b4ebf476dbdd1740