### PR TITLE
Update registration endpoint detection

### DIFF
--- a/orchestration/main.py
+++ b/orchestration/main.py
@@ -49,12 +49,12 @@ async def handle_tool_request(request: Dict[str, Any]):
     """
     Handle tool requests from agents.
     This endpoint either:
-    1. Registers new agent capabilities if the request contains registration data
-    2. Routes tool requests to the appropriate agent
+    1. Registers new agent capabilities when ``request.get("tool") == "register_agent"``
+    2. Routes tool requests to the appropriate agent for any other tool name
     """
     try:
         # Check if this is a registration request
-        if "name" in request and "capabilities" in request:
+        if request.get("tool") == "register_agent":
             result = await registry_tool.execute(request)
             return {"status": "success", "message": "Agent registered successfully", "data": result}
         

--- a/orchestration/tests/test_orchestration.py
+++ b/orchestration/tests/test_orchestration.py
@@ -10,6 +10,8 @@ from typing import Dict, Any
 import uuid
 import json
 from datetime import datetime
+from fastapi.testclient import TestClient
+from meepzorp.orchestration.main import app
 
 from meepzorp.orchestration.registry import AgentRegistryTool, AgentDiscoveryTool
 from meepzorp.orchestration.router import RouteRequestTool
@@ -195,4 +197,16 @@ async def test_workflow_error_handling(mock_workflow):
         "input_variables": {}
     })
     assert execute_result["status"] == "error"
-    assert "message" in execute_result 
+    assert "message" in execute_result
+
+
+def test_agent_registration_endpoint(mock_agent_info):
+    """Ensure agents can register via the /mcp/tools endpoint."""
+    client = TestClient(app)
+    payload = {"tool": "register_agent", **mock_agent_info}
+    response = client.post("/mcp/tools", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "success"
+    assert data["data"]["status"] == "success"
+    assert "agent_id" in data["data"]


### PR DESCRIPTION
## Summary
- detect `/mcp/tools` registration requests via `tool == register_agent`
- document new behaviour in `handle_tool_request`
- test registering an agent through the FastAPI endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for required packages)*

------
https://chatgpt.com/codex/tasks/task_e_6840847f2204832196b0da379686927e