### PR TITLE
Update agent registration payload

### DIFF
--- a/agents/common/registration.py
+++ b/agents/common/registration.py
@@ -3,7 +3,6 @@ Agent registration module for MCP agents.
 """
 import os
 import httpx
-import asyncio
 from typing import List, Dict, Any
 from loguru import logger
 
@@ -45,10 +44,7 @@ async def register_agent(name: str, description: str, capabilities: List[Dict[st
         async with httpx.AsyncClient() as client:
             response = await client.post(
                 f"{orchestration_url}/mcp/tools",
-                json={
-                    "name": "register_agent",
-                    "parameters": registration_data
-                }
+                json=registration_data,
             )
             response.raise_for_status()
             result = response.json()


### PR DESCRIPTION
## Summary
- send agent details directly to orchestration instead of nested `parameters`
- register the Document Processor agent through the common helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_openai')*

------
https://chatgpt.com/codex/tasks/task_e_6840982d19c4832199ec3938e2837d99