### PR TITLE
Implement registry-based routing

### DIFF
--- a/orchestration/router.py
+++ b/orchestration/router.py
@@ -1,21 +1,91 @@
-"""
-Request routing tool for the orchestration system.
-"""
-from typing import Dict, Any
+"""Request routing tool for the orchestration system."""
+
+from __future__ import annotations
+
+import asyncio
 import logging
+import os
+from typing import Any, Dict, List
+
+import httpx
+
+from .registry import AgentDiscoveryTool
 
 logger = logging.getLogger(__name__)
 
+
 class RouteRequestTool:
     """Tool for routing requests to appropriate agents."""
-    
+
+    def __init__(self, registry_url: str | None = None) -> None:
+        self.registry_url = registry_url or os.getenv(
+            "REGISTRY_URL", "http://localhost:8000"
+        )
+        self.discovery_tool = AgentDiscoveryTool(self.registry_url)
+
+    async def _discover_agents(self, capability: str) -> List[Dict[str, Any]]:
+        """Return agents that provide the requested capability."""
+        discovery_result = await self.discovery_tool.execute(
+            {"capabilities": [capability]}
+        )
+        agents = discovery_result.get("agents", [])
+        return [
+            a
+            for a in agents
+            if any(cap.get("name") == capability for cap in a.get("capabilities", []))
+        ]
+
     async def execute(self, request: Dict[str, Any]) -> Dict[str, Any]:
         """Route a request to an agent."""
-        logger.info(f"Routing request for capability: {request['capability']}")
-        return {
-            "status": "success",
-            "result": {
-                "received_params": request["parameters"],
-                "mock_response": "Test response from mock agent"
-            }
-        } 
+        capability = request.get("capability")
+        params = request.get("parameters", {})
+        preferred_agent_id = request.get("preferred_agent_id")
+        timeout = request.get("timeout", 5.0)
+
+        logger.info("Routing request for capability: %s", capability)
+
+        try:
+            agents = await self._discover_agents(capability)
+            if not agents:
+                return {
+                    "status": "error",
+                    "message": f"No agent found for capability '{capability}'",
+                }
+
+            agent: Dict[str, Any] | None = None
+            if preferred_agent_id:
+                agent = next(
+                    (a for a in agents if str(a.get("id")) == str(preferred_agent_id)),
+                    None,
+                )
+                if agent is None:
+                    return {
+                        "status": "error",
+                        "message": "Preferred agent not available",
+                    }
+            else:
+                agent = agents[0]
+
+            endpoint = agent.get("endpoint")
+            if not endpoint:
+                return {"status": "error", "message": "Agent endpoint missing"}
+
+            payload = {"capability": capability, "parameters": params}
+            retries = 1
+            for attempt in range(retries + 1):
+                try:
+                    async with httpx.AsyncClient(timeout=timeout) as client:
+                        response = await client.post(f"{endpoint}/mcp", json=payload)
+                        response.raise_for_status()
+                        return response.json()
+                except (
+                    httpx.RequestError,
+                    httpx.HTTPStatusError,
+                ) as exc:  # pragma: no cover - network issues
+                    logger.warning("Routing attempt %s failed: %s", attempt + 1, exc)
+                    if attempt == retries:
+                        return {"status": "error", "message": str(exc)}
+                    await asyncio.sleep(0.1)
+        except Exception as exc:  # pragma: no cover - unexpected issues
+            logger.error("Routing error: %s", exc)
+            return {"status": "error", "message": str(exc)}

--- a/orchestration/tests/test_orchestration.py
+++ b/orchestration/tests/test_orchestration.py
@@ -3,18 +3,24 @@ Tests for the orchestration system components.
 
 This module provides integration tests for the registry, router, and workflow components.
 """
+
+import asyncio
+import json
+import uuid
+from datetime import datetime
+from typing import Any, Dict
+
+import httpx
 import pytest
 import pytest_asyncio
-import asyncio
-from typing import Dict, Any
-import uuid
-import json
-from datetime import datetime
-import httpx
 
-from meepzorp.orchestration.registry import AgentRegistryTool, AgentDiscoveryTool
+from meepzorp.orchestration.registry import AgentDiscoveryTool, AgentRegistryTool
 from meepzorp.orchestration.router import RouteRequestTool
-from meepzorp.orchestration.workflows import ExecuteWorkflowTool, CreateWorkflowTool, ListWorkflowsTool
+from meepzorp.orchestration.workflows import (
+    CreateWorkflowTool,
+    ExecuteWorkflowTool,
+    ListWorkflowsTool,
+)
 
 
 class MockResponse:
@@ -39,30 +45,51 @@ class MockAsyncClient:
         if url.endswith("/agents"):
             return MockResponse({"status": "success", "agent_id": "test_agent_id"})
         if url.endswith("/workflows/execute"):
-            return MockResponse({"status": "success", "results": {"step1": {"status": "success", "output": "Test output"}}})
+            return MockResponse(
+                {
+                    "status": "success",
+                    "results": {
+                        "step1": {"status": "success", "output": "Test output"}
+                    },
+                }
+            )
         if url.endswith("/workflows"):
             return MockResponse({"status": "success", "workflow_id": str(uuid.uuid4())})
         return MockResponse({})
 
     async def get(self, url, params=None):
         if url.endswith("/agents"):
-            return MockResponse({
-                "status": "success",
-                "agents": [
-                    {
-                        "name": "test_agent",
-                        "capabilities": [{"name": "test_capability", "description": "Test capability"}],
-                        "endpoint": "http://localhost:8811",
-                    }
-                ],
-            })
+            return MockResponse(
+                {
+                    "status": "success",
+                    "agents": [
+                        {
+                            "id": "test_agent_id",
+                            "name": "test_agent",
+                            "capabilities": [
+                                {
+                                    "name": "test_capability",
+                                    "description": "Test capability",
+                                }
+                            ],
+                            "endpoint": "http://localhost:8811",
+                        }
+                    ],
+                }
+            )
         if url.endswith("/workflows"):
-            return MockResponse({
-                "status": "success",
-                "workflows": [
-                    {"id": "test_workflow_id", "name": "Test Workflow", "description": "A test workflow"}
-                ],
-            })
+            return MockResponse(
+                {
+                    "status": "success",
+                    "workflows": [
+                        {
+                            "id": "test_workflow_id",
+                            "name": "Test Workflow",
+                            "description": "A test workflow",
+                        }
+                    ],
+                }
+            )
         return MockResponse({})
 
 
@@ -70,6 +97,7 @@ class MockAsyncClient:
 async def patch_httpx(monkeypatch):
     monkeypatch.setattr(httpx, "AsyncClient", MockAsyncClient)
     yield
+
 
 @pytest_asyncio.fixture
 async def mock_agent_info():
@@ -79,11 +107,9 @@ async def mock_agent_info():
         "description": "Test agent for integration testing",
         "endpoint": "http://localhost:8811",
         "capabilities": [{"name": "test_capability", "description": "Test capability"}],
-        "metadata": {
-            "version": "1.0.0",
-            "environment": "test"
-        }
+        "metadata": {"version": "1.0.0", "environment": "test"},
     }
+
 
 @pytest_asyncio.fixture
 async def registered_agent(mock_agent_info):
@@ -92,6 +118,7 @@ async def registered_agent(mock_agent_info):
     result = await registry.execute(mock_agent_info)
     assert result["status"] == "success"
     return result["agent_id"]
+
 
 @pytest_asyncio.fixture
 def mock_workflow():
@@ -105,15 +132,12 @@ def mock_workflow():
                 "name": "Test Step",
                 "description": "A test step",
                 "capability": "test_capability",
-                "parameters": {
-                    "test_param": "test_value"
-                }
+                "parameters": {"test_param": "test_value"},
             }
         ],
-        "variables": {
-            "test_var": "test_value"
-        }
+        "variables": {"test_var": "test_value"},
     }
+
 
 @pytest.mark.asyncio
 async def test_agent_registry_and_discovery():
@@ -121,60 +145,64 @@ async def test_agent_registry_and_discovery():
     # Initialize tools
     registry = AgentRegistryTool()
     discovery = AgentDiscoveryTool()
-    
+
     # Register a test agent
     agent_info = {
         "name": "test_agent",
         "description": "Test agent for integration testing",
         "endpoint": "http://localhost:8811",
         "capabilities": [{"name": "test_capability", "description": "Test capability"}],
-        "metadata": {"version": "1.0.0"}
+        "metadata": {"version": "1.0.0"},
     }
-    
+
     result = await registry.execute(agent_info)
     assert result["status"] == "success"
     assert "agent_id" in result
-    
+
     # Give the registry a moment to process
     await asyncio.sleep(0.1)
-    
+
     # Discover agents
-    discovery_result = await discovery.execute({
-        "capabilities": ["test_capability"]
-    })
+    discovery_result = await discovery.execute({"capabilities": ["test_capability"]})
     assert discovery_result["status"] == "success"
     assert len(discovery_result["agents"]) > 0
-    
+
     # Verify agent info
     found_agent = False
     for agent in discovery_result["agents"]:
         if agent["name"] == "test_agent":
             found_agent = True
-            assert any(cap["name"] == "test_capability" for cap in agent["capabilities"])
+            assert any(
+                cap["name"] == "test_capability" for cap in agent["capabilities"]
+            )
             assert agent["endpoint"] == "http://localhost:8811"
             break
     assert found_agent, "Expected agent not found in discovery results"
+
 
 @pytest.mark.asyncio
 async def test_request_routing(registered_agent):
     """Test request routing to registered agent."""
     router = RouteRequestTool()
-    
+
     # Give the registry a moment to process
     await asyncio.sleep(0.1)
-    
+
     # Route a test request
-    result = await router.execute({
-        "capability": "test_capability",
-        "parameters": {
-            "test_param": "test_value"
-        },
-        "preferred_agent_id": str(registered_agent),  # Ensure it's a string
-        "timeout": 5.0
-    })
-    
-    assert result["status"] == "success", f"Request routing failed: {result.get('message', 'No error message')}"
+    result = await router.execute(
+        {
+            "capability": "test_capability",
+            "parameters": {"test_param": "test_value"},
+            "preferred_agent_id": str(registered_agent),  # Ensure it's a string
+            "timeout": 5.0,
+        }
+    )
+
+    assert (
+        result["status"] == "success"
+    ), f"Request routing failed: {result.get('message', 'No error message')}"
     assert "result" in result, "Response missing result field"
+
 
 @pytest.mark.asyncio
 async def test_workflow_creation_and_execution(mock_workflow):
@@ -182,24 +210,28 @@ async def test_workflow_creation_and_execution(mock_workflow):
     # Create workflow
     creator = CreateWorkflowTool()
     create_result = await creator.execute(mock_workflow)
-    assert create_result["status"] == "success", f"Workflow creation failed: {create_result.get('message', 'No error message')}"
+    assert (
+        create_result["status"] == "success"
+    ), f"Workflow creation failed: {create_result.get('message', 'No error message')}"
     assert "workflow_id" in create_result
-    
+
     # List workflows
     lister = ListWorkflowsTool()
     list_result = await lister.execute({})
     assert list_result["status"] == "success"
     assert len(list_result["workflows"]) > 0
-    
+
     # Execute workflow
     executor = ExecuteWorkflowTool()
-    execute_result = await executor.execute({
-        "workflow_id": create_result["workflow_id"],
-        "input_variables": {
-            "test_input": "test_value"
+    execute_result = await executor.execute(
+        {
+            "workflow_id": create_result["workflow_id"],
+            "input_variables": {"test_input": "test_value"},
         }
-    })
-    assert execute_result["status"] == "success", f"Workflow execution failed: {execute_result.get('message', 'No error message')}"
+    )
+    assert (
+        execute_result["status"] == "success"
+    ), f"Workflow execution failed: {execute_result.get('message', 'No error message')}"
     assert "results" in execute_result
 
 
@@ -211,59 +243,59 @@ async def test_execute_workflow_invalid_id(mock_workflow):
     assert create_result["status"] == "success"
 
     executor = ExecuteWorkflowTool()
-    execute_result = await executor.execute({
-        "workflow_id": "bogus_id",
-        "input_variables": {}
-    })
+    execute_result = await executor.execute(
+        {"workflow_id": "bogus_id", "input_variables": {}}
+    )
     assert execute_result["status"] == "error"
+
 
 @pytest.mark.asyncio
 async def test_error_handling():
     """Test error handling in orchestration components."""
     router = RouteRequestTool()
-    
+
     # Test invalid capability
-    result = await router.execute({
-        "capability": "nonexistent_capability",
-        "parameters": {},
-        "timeout": 1.0
-    })
+    result = await router.execute(
+        {"capability": "nonexistent_capability", "parameters": {}, "timeout": 1.0}
+    )
     assert result["status"] == "error"
     assert "message" in result
-    
+
     # Test invalid agent ID
-    result = await router.execute({
-        "capability": "test_capability",
-        "parameters": {},
-        "preferred_agent_id": "invalid_id",
-        "timeout": 1.0
-    })
+    result = await router.execute(
+        {
+            "capability": "test_capability",
+            "parameters": {},
+            "preferred_agent_id": "invalid_id",
+            "timeout": 1.0,
+        }
+    )
     assert result["status"] == "error"
     assert "message" in result
+
 
 @pytest.mark.asyncio
 async def test_workflow_error_handling(mock_workflow):
     """Test workflow error handling."""
     creator = CreateWorkflowTool()
     executor = ExecuteWorkflowTool()
-    
+
     # Create workflow
     create_result = await creator.execute(mock_workflow)
     assert create_result["status"] == "success"
-    
+
     # Test execution with invalid input
-    execute_result = await executor.execute({
-        "workflow_id": create_result["workflow_id"],
-        "input_variables": {
-            "invalid_input": "this_should_fail"
+    execute_result = await executor.execute(
+        {
+            "workflow_id": create_result["workflow_id"],
+            "input_variables": {"invalid_input": "this_should_fail"},
         }
-    })
+    )
     assert "partial_results" in execute_result
-    
+
     # Test execution with invalid workflow ID
-    execute_result = await executor.execute({
-        "workflow_id": "invalid_workflow_id",
-        "input_variables": {}
-    })
+    execute_result = await executor.execute(
+        {"workflow_id": "invalid_workflow_id", "input_variables": {}}
+    )
     assert execute_result["status"] == "error"
-    assert "message" in execute_result 
+    assert "message" in execute_result

--- a/orchestration/tests/test_router_unit.py
+++ b/orchestration/tests/test_router_unit.py
@@ -1,0 +1,67 @@
+import httpx
+import pytest
+import pytest_asyncio
+
+from meepzorp.orchestration.router import RouteRequestTool
+
+
+class MockResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        pass
+
+
+class CaptureAsyncClient:
+    def __init__(self):
+        self.sent = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, url, json=None):
+        self.sent.append((url, json))
+        return MockResponse({"status": "success", "result": {"ok": True}})
+
+    async def get(self, url, params=None):
+        if url.endswith("/agents"):
+            return MockResponse(
+                {
+                    "status": "success",
+                    "agents": [
+                        {
+                            "id": "test_agent_id",
+                            "endpoint": "http://agent.test",
+                            "capabilities": [{"name": "test_capability"}],
+                        }
+                    ],
+                }
+            )
+        return MockResponse({})
+
+
+@pytest_asyncio.fixture
+def capture_client(monkeypatch):
+    client = CaptureAsyncClient()
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **k: client)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_router_forwards_request(capture_client):
+    router = RouteRequestTool()
+    result = await router.execute(
+        {"capability": "test_capability", "parameters": {"x": 1}}
+    )
+    assert result["status"] == "success"
+    assert capture_client.sent
+    url, payload = capture_client.sent[0]
+    assert url == "http://agent.test/mcp"
+    assert payload["capability"] == "test_capability"


### PR DESCRIPTION
## Summary
- route requests through the registry in `RouteRequestTool`
- handle unavailable agents and retry failed requests
- extend test helpers with agent IDs
- add unit test covering async routing via httpx

## Testing
- `black orchestration/router.py orchestration/tests/test_orchestration.py orchestration/tests/test_router_unit.py`
- `isort orchestration/router.py orchestration/tests/test_orchestration.py orchestration/tests/test_router_unit.py`
- `pytest -q` *(fails: ModuleNotFoundError for optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68409831908c8321bd53458861f32d35