### PR TITLE
Remove unused test-agent service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,26 +135,6 @@ services:
       - orchestration
     command: sh -c "npm run build && npm start"
 
-  # Test agent - For testing and development
-  test-agent:
-    build:
-      context: ./agent
-      dockerfile: Dockerfile
-    container_name: meepzorp-test-agent
-    # Test agent port - used for development and testing
-    ports:
-      - "${TEST_AGENT_PORT:-9811}:${TEST_AGENT_PORT:-9811}"
-    environment:
-      - AGENT_PORT=${TEST_AGENT_PORT:-9811}
-      - AGENT_HOST=0.0.0.0
-      - AGENT_EXTERNAL_HOST=test-agent
-      - ORCHESTRATION_URL=http://orchestration:${ORCHESTRATION_PORT:-9810}
-      - LOG_LEVEL=INFO
-    depends_on:
-      orchestration:
-        condition: service_healthy
-    networks:
-      - mcp-net
 
   # Task management agent - Manages tasks and project management
   task-agent:

--- a/docs/setup/port-configuration.md
+++ b/docs/setup/port-configuration.md
@@ -12,7 +12,6 @@ The following ports are used by various services in the system:
 | Base Agent | 8001 | Template for new agent development |
 | Personal Agent | 8002 | Personal knowledge agent |
 | Task Agent | 8003 | Task management agent |
-| Test Agent | 9811 | Testing and development agent |
 | UI | 3000 | Management dashboard |
 | Redis | 6379 | Cache and pub/sub messaging |
 
@@ -24,14 +23,13 @@ When setting up a new project or agent, follow these steps to ensure correct por
    - Copy `.env.example` to `.env`
    - Set the following port variables:
      ```
-     ORCHESTRATION_PORT=9810
-     BASE_AGENT_PORT=8001
-     PERSONAL_AGENT_PORT=8002
-     TASK_AGENT_PORT=8003
-     TEST_AGENT_PORT=9811
-     REDIS_PORT=6379
-     UI_PORT=3000
-     ```
+    ORCHESTRATION_PORT=9810
+    BASE_AGENT_PORT=8001
+    PERSONAL_AGENT_PORT=8002
+    TASK_AGENT_PORT=8003
+    REDIS_PORT=6379
+    UI_PORT=3000
+    ```
 
 2. **Docker Compose Configuration**
    - Ensure port mappings in `docker-compose.yml` match the environment variables


### PR DESCRIPTION
## Summary
- remove `test-agent` from compose
- update port configuration doc

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6840984b3ad48321883c38725a811cdc