### PR TITLE
Update agent registration payload

### DIFF
--- a/agents/base/src/registration.py
+++ b/agents/base/src/registration.py
@@ -47,8 +47,8 @@ async def register_agent(name: str, description: str, capabilities: List[Dict[st
                 f"{orchestration_url}/mcp/tools",
                 json={
                     "tool": "register_agent",
-                    "parameters": registration_data
-                }
+                    **registration_data,
+                },
             )
             response.raise_for_status()
             result = response.json()

--- a/agents/common/registration.py
+++ b/agents/common/registration.py
@@ -46,9 +46,9 @@ async def register_agent(name: str, description: str, capabilities: List[Dict[st
             response = await client.post(
                 f"{orchestration_url}/mcp/tools",
                 json={
-                    "name": "register_agent",
-                    "parameters": registration_data
-                }
+                    "tool": "register_agent",
+                    **registration_data,
+                },
             )
             response.raise_for_status()
             result = response.json()

--- a/docs/setup/agent-setup.md
+++ b/docs/setup/agent-setup.md
@@ -43,8 +43,20 @@ Agents must register with the orchestration service to participate in the system
                description="What your agent does",
                capabilities=capabilities
            )
-       except Exception as e:
-           logger.error(f"Failed to register agent: {str(e)}")
+    except Exception as e:
+        logger.error(f"Failed to register agent: {str(e)}")
+   ```
+
+   The registration request sent to the orchestration service looks like:
+
+   ```json
+   {
+       "tool": "register_agent",
+       "name": "Your Agent Name",
+       "description": "What your agent does",
+       "endpoint": "http://your-agent:8000",
+       "capabilities": [...]
+   }
    ```
 
 3. **Docker Configuration**


### PR DESCRIPTION
## Summary
- simplify JSON payload for agent registration
- adjust base registration helper
- show example registration payload in documentation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68409b70c2dc83218330c5b9103cd85c