### PR TITLE
Fix sync fixture in orchestration tests

### DIFF
--- a/orchestration/tests/test_orchestration.py
+++ b/orchestration/tests/test_orchestration.py
@@ -71,8 +71,8 @@ async def patch_httpx(monkeypatch):
     monkeypatch.setattr(httpx, "AsyncClient", MockAsyncClient)
     yield
 
-@pytest_asyncio.fixture
-async def mock_agent_info():
+@pytest.fixture
+def mock_agent_info():
     """Fixture providing mock agent information."""
     return {
         "name": "test_agent",


### PR DESCRIPTION
## Summary
- simplify `mock_agent_info` to a synchronous fixture

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_openai')*

------
https://chatgpt.com/codex/tasks/task_e_68409b75e00883219c947196562a9224