### PR TITLE
Add registry service

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ docker compose up -d
 | Personal Agent    | http://localhost:8002 |
 | Task Agent        | http://localhost:8003 |
 | Document Processor| http://localhost:8004 |
+| Registry Service  | http://localhost:8005 |
 | UI Dashboard      | http://localhost:3000 |
 
 Port mapping details live in [`docs/setup/port-configuration.md`](docs/setup/port-configuration.md).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -204,6 +204,30 @@ services:
       retries: 3
       start_period: 5s
 
+  registry-service:
+    build:
+      context: ./registry_service
+      dockerfile: Dockerfile
+    container_name: meepzorp-registry-service
+    restart: unless-stopped
+    environment:
+      - SUPABASE_URL=${SUPABASE_URL}
+      - SUPABASE_KEY=${SUPABASE_KEY}
+      - REGISTRY_PORT=${REGISTRY_PORT:-8005}
+    ports:
+      - "${REGISTRY_PORT:-8005}:${REGISTRY_PORT:-8005}"
+    networks:
+      - mcp-net
+    depends_on:
+      orchestration:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:${REGISTRY_PORT:-8005}/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+
 networks:
   mcp-net:
     driver: bridge

--- a/docs/setup/port-configuration.md
+++ b/docs/setup/port-configuration.md
@@ -12,6 +12,8 @@ The following ports are used by various services in the system:
 | Base Agent | 8001 | Template for new agent development |
 | Personal Agent | 8002 | Personal knowledge agent |
 | Task Agent | 8003 | Task management agent |
+| Document Processor | 8004 | Document analysis service |
+| Registry Service | 8005 | Stores agent metadata |
 | UI | 3000 | Management dashboard |
 | Redis | 6379 | Cache and pub/sub messaging |
 
@@ -27,6 +29,8 @@ When setting up a new project or agent, follow these steps to ensure correct por
     BASE_AGENT_PORT=8001
     PERSONAL_AGENT_PORT=8002
     TASK_AGENT_PORT=8003
+    DOCUMENT_PROCESSOR_PORT=8004
+    REGISTRY_PORT=8005
     REDIS_PORT=6379
     UI_PORT=3000
     ```

--- a/registry_service/Dockerfile
+++ b/registry_service/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONPATH=/app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+RUN echo '#!/bin/sh\nuvicorn main:app --host 0.0.0.0 --port ${REGISTRY_PORT:-8005}' > /app/start.sh && \
+    chmod +x /app/start.sh
+
+EXPOSE ${REGISTRY_PORT:-8005}
+
+CMD ["/app/start.sh"]

--- a/registry_service/main.py
+++ b/registry_service/main.py
@@ -1,0 +1,89 @@
+import os
+import logging
+from typing import List, Dict, Any, Optional
+
+from fastapi import FastAPI, HTTPException
+import httpx
+
+
+logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="Agent Registry Service")
+
+
+class RegistryDB:
+    """Simple Supabase client for the agents table."""
+
+    def __init__(self) -> None:
+        self.supabase_url = os.getenv("SUPABASE_URL")
+        self.supabase_key = os.getenv("SUPABASE_KEY")
+        if not self.supabase_url or not self.supabase_key:
+            raise ValueError("SUPABASE_URL and SUPABASE_KEY must be set")
+
+        self.headers = {
+            "apikey": self.supabase_key,
+            "Authorization": f"Bearer {self.supabase_key}",
+            "Content-Type": "application/json",
+            "Prefer": "return=representation",
+        }
+
+    async def add_agent(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{self.supabase_url}/rest/v1/agents",
+                headers=self.headers,
+                json=data,
+            )
+        if resp.status_code != 201:
+            raise Exception(f"Failed to store agent: {resp.text}")
+        result = resp.json()[0] if isinstance(resp.json(), list) else resp.json()
+        return result
+
+    async def list_agents(self, capability: Optional[str] = None) -> List[Dict[str, Any]]:
+        params = {}
+        if capability:
+            params["capabilities"] = f"cs.[{{\"name\":\"{capability}\"}}]"
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{self.supabase_url}/rest/v1/agents",
+                headers=self.headers,
+                params=params,
+            )
+        if resp.status_code != 200:
+            raise Exception(f"Failed to fetch agents: {resp.text}")
+        return resp.json()
+
+
+db = RegistryDB()
+
+
+@app.get("/health")
+async def health_check():
+    return {"status": "healthy"}
+
+
+@app.post("/agents")
+async def register_agent(agent: Dict[str, Any]):
+    try:
+        result = await db.add_agent(agent)
+        return {"status": "success", "agent_id": result["id"]}
+    except Exception as e:
+        logger.error(f"Error storing agent: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.get("/agents")
+async def get_agents(capabilities: Optional[str] = None):
+    try:
+        agents = await db.list_agents(capabilities)
+        return {"status": "success", "agents": agents}
+    except Exception as e:
+        logger.error(f"Error retrieving agents: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("REGISTRY_PORT", "8005")))

--- a/registry_service/requirements.txt
+++ b/registry_service/requirements.txt
@@ -1,0 +1,6 @@
+fastapi>=0.104.1
+uvicorn>=0.24.0
+httpx>=0.25.1
+python-dotenv>=1.0.0
+pydantic>=2.5.1
+loguru>=0.7.2

--- a/registry_service/tests/test_main.py
+++ b/registry_service/tests/test_main.py
@@ -1,0 +1,48 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from registry_service.main import app, RegistryDB
+
+class MockResponse:
+    def __init__(self, status_code: int, json_data=None, text=""):
+        self.status_code = status_code
+        self._json = json_data
+        self.text = text
+
+    def json(self):
+        return self._json
+
+@pytest.fixture(autouse=True)
+def set_env(monkeypatch):
+    monkeypatch.setenv("SUPABASE_URL", "http://localhost")
+    monkeypatch.setenv("SUPABASE_KEY", "key")
+
+@pytest.fixture
+def client(mocker):
+    mock_db = RegistryDB()
+    mock_client = TestClient(app)
+    return mock_client
+
+def test_register_agent(mocker, client):
+    async_mock = mocker.AsyncMock()
+    async_mock.__aenter__.return_value = async_mock
+    async_mock.post.return_value = MockResponse(201, [{"id": "123"}])
+    mocker.patch("httpx.AsyncClient", return_value=async_mock)
+
+    response = client.post("/agents", json={"name": "a"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "success"
+    assert body["agent_id"] == "123"
+
+def test_get_agents(mocker, client):
+    async_mock = mocker.AsyncMock()
+    async_mock.__aenter__.return_value = async_mock
+    async_mock.get.return_value = MockResponse(200, [{"id": "1", "capabilities": []}])
+    mocker.patch("httpx.AsyncClient", return_value=async_mock)
+
+    response = client.get("/agents", params={"capabilities": "echo"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "success"
+    assert isinstance(data["agents"], list)


### PR DESCRIPTION
## Summary
- implement registry_service FastAPI app for agent storage
- add Dockerfile and include service in docker-compose
- document registry service port configuration
- provide unit tests with mocked httpx calls

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_openai', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684b08c11078832181e36b2dc202624e