### PR TITLE
Fix orchestration test imports

### DIFF
--- a/orchestration/tests/test_orchestration.py
+++ b/orchestration/tests/test_orchestration.py
@@ -5,11 +5,9 @@ This module provides integration tests for the registry, router, and workflow co
 """
 
 import asyncio
-import uuid
-
-
 import sys
 import types
+import uuid
 
 try:  # httpx may not be installed in the execution environment
     import httpx  # type: ignore


### PR DESCRIPTION
## Summary
- remove redundant whitespace in orchestration tests
- reorder imports in `test_orchestration.py`

## Testing
- `pytest -q orchestration/tests/test_orchestration.py` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_684d1612becc83218136efc92efe8ed2