### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ cp .env.example .env
 # ‼️  Edit .env and fill in:
 #     SUPABASE_URL, SUPABASE_KEY, OPENAI_API_KEY  (and any optional overrides)
 # Install Python dependencies (required for running tests)
+# `requirements.txt` includes development packages such as
+# `pytest-asyncio`, `httpx`, and `python-dotenv` which are needed when
+# running the test suite.
 pip install -r requirements.txt
 pip install -r orchestration/requirements.txt
 ```

--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,7 @@ setup(
         "fastapi",
         "uvicorn",
         "pydantic",
+        "httpx",
+        "python-dotenv",
     ],
-) 
+)


### PR DESCRIPTION
## Summary
- clarify requirement installation instructions in README
- include httpx and python-dotenv in setup.py install requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_openai')*

------
https://chatgpt.com/codex/tasks/task_e_685d913ebb6c832188967879b8771400