### PR TITLE
Ensure orchestration tests require optional deps

### DIFF
--- a/orchestration/tests/test_orchestration.py
+++ b/orchestration/tests/test_orchestration.py
@@ -5,24 +5,15 @@ This module provides integration tests for the registry, router, and workflow co
 """
 
 import asyncio
-import sys
-import types
 import uuid
-
-try:  # httpx may not be installed in the execution environment
-    import httpx  # type: ignore
-except ModuleNotFoundError:  # pragma: no cover - fallback for minimal test env
-    httpx = types.ModuleType("httpx")
-    class _DummyClient:  # minimal stand-in so module import succeeds
-        async def __aenter__(self):
-            return self
-        async def __aexit__(self, exc_type, exc, tb):
-            pass
-    httpx.AsyncClient = _DummyClient
-    sys.modules["httpx"] = httpx
-
 import pytest
-import pytest_asyncio
+
+httpx = pytest.importorskip(
+    "httpx", reason="httpx is required for orchestration tests"
+)
+pytest_asyncio = pytest.importorskip(
+    "pytest_asyncio", reason="pytest_asyncio is required for orchestration tests"
+)
 
 from meepzorp.orchestration.registry import AgentDiscoveryTool, AgentRegistryTool
 from meepzorp.orchestration.router import RouteRequestTool


### PR DESCRIPTION
## Summary
- remove `httpx` stub from orchestration tests
- skip tests if `httpx` or `pytest_asyncio` aren't installed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_openai')*

------
https://chatgpt.com/codex/tasks/task_e_685d91438a748321aa7ec84657b77990