### PR TITLE
Add env example & update docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# Example environment configuration for Meepzorp
+
+# Supabase credentials
+SUPABASE_URL=
+SUPABASE_KEY=
+
+# OpenAI API
+OPENAI_API_KEY=
+
+# Registry service configuration
+REGISTRY_URL=http://localhost:8005
+REGISTRY_PORT=8005
+
+# Orchestration service
+ORCHESTRATION_PORT=9810
+
+# Agent service ports
+BASE_AGENT_PORT=8001
+PERSONAL_AGENT_PORT=8002
+TASK_AGENT_PORT=8003
+DOCUMENT_PROCESSOR_PORT=8004
+
+# Supporting services
+REDIS_PORT=6379
+UI_PORT=3000

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Environment variables
 .env*
+!.env.example
 
 # Python
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -66,8 +66,11 @@ cd meepzorp
 
 # Create your env file *in the repo root*
 cp .env.example .env
-# ‼️  Edit .env and fill in:
-#     SUPABASE_URL, SUPABASE_KEY, OPENAI_API_KEY  (and any optional overrides)
+# ‼️  Edit .env and fill in values for:
+#     SUPABASE_URL, SUPABASE_KEY, OPENAI_API_KEY
+#     REGISTRY_URL, REGISTRY_PORT, ORCHESTRATION_PORT
+#     BASE_AGENT_PORT, PERSONAL_AGENT_PORT, TASK_AGENT_PORT, DOCUMENT_PROCESSOR_PORT
+#     UI_PORT, REDIS_PORT (and any optional overrides)
 # Install Python dependencies (required for running tests)
 pip install -r requirements.txt
 pip install -r orchestration/requirements.txt


### PR DESCRIPTION
## Summary
- add `.env.example` template and track it in git
- document required environment variables in README
- allow `.env.example` through `.gitignore`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_openai')*

------
https://chatgpt.com/codex/tasks/task_e_685d9159f0e08321b32bdb96f26ab83d