### PR TITLE
Add tasks and knowledge migrations

### DIFF
--- a/supabase/migrations/20250626183035_create_tasks_table.sql
+++ b/supabase/migrations/20250626183035_create_tasks_table.sql
@@ -1,0 +1,58 @@
+-- +migrate Up
+create table if not exists public.tasks (
+    id uuid primary key default gen_random_uuid(),
+    title text not null,
+    description text,
+    status text not null default 'todo',
+    priority text not null default 'medium',
+    due_date timestamp with time zone,
+    assignee text,
+    project_id uuid,
+    tags jsonb not null default '[]'::jsonb,
+    created_at timestamp with time zone not null default now(),
+    updated_at timestamp with time zone not null default now(),
+    created_by uuid references auth.users(id),
+    updated_by uuid references auth.users(id)
+);
+
+alter table public.tasks enable row level security;
+
+create policy "Tasks are viewable by all users"
+    on public.tasks for select
+    using (true);
+
+create policy "Tasks are insertable by authenticated users"
+    on public.tasks for insert
+    with check (auth.role() = 'authenticated');
+
+create policy "Tasks are updatable by authenticated users"
+    on public.tasks for update
+    using (auth.role() = 'authenticated');
+
+create index tasks_status_idx on public.tasks(status);
+create index tasks_priority_idx on public.tasks(priority);
+create index tasks_project_id_idx on public.tasks(project_id);
+create index tasks_assignee_idx on public.tasks(assignee);
+create index tasks_created_at_idx on public.tasks(created_at);
+
+create or replace function public.handle_task_updated_at()
+returns trigger as $$
+begin
+    new.updated_at = now();
+    return new;
+end;
+$$ language plpgsql;
+
+create trigger set_task_updated_at
+    before update on public.tasks
+    for each row
+    execute procedure public.handle_task_updated_at();
+
+-- +migrate Down
+
+drop trigger if exists set_task_updated_at on public.tasks;
+drop function if exists public.handle_task_updated_at;
+drop policy if exists "Tasks are updatable by authenticated users" on public.tasks;
+drop policy if exists "Tasks are insertable by authenticated users" on public.tasks;
+drop policy if exists "Tasks are viewable by all users" on public.tasks;
+drop table if exists public.tasks;

--- a/supabase/migrations/20250626183036_create_knowledge_table.sql
+++ b/supabase/migrations/20250626183036_create_knowledge_table.sql
@@ -1,0 +1,50 @@
+-- +migrate Up
+create extension if not exists vector;
+
+create table if not exists public.knowledge (
+    id uuid default gen_random_uuid() primary key,
+    content text not null,
+    tags jsonb not null default '[]'::jsonb,
+    embedding vector(1536),
+    created_at timestamp with time zone not null default now(),
+    updated_at timestamp with time zone not null default now()
+);
+
+create index if not exists idx_knowledge_tags on public.knowledge using gin (tags);
+create index if not exists idx_knowledge_embedding on public.knowledge using ivfflat (embedding vector_cosine_ops);
+
+alter table public.knowledge enable row level security;
+
+create policy "Enable read access for all users" on public.knowledge
+    for select
+    using (true);
+
+create policy "Enable insert for authenticated users" on public.knowledge
+    for insert
+    with check (auth.role() = 'authenticated');
+
+create policy "Enable update for authenticated users" on public.knowledge
+    for update
+    using (auth.role() = 'authenticated');
+
+create or replace function public.handle_knowledge_updated_at()
+returns trigger as $$
+begin
+    new.updated_at = now();
+    return new;
+end;
+$$ language plpgsql;
+
+create trigger handle_knowledge_updated_at
+    before update on public.knowledge
+    for each row
+    execute procedure public.handle_knowledge_updated_at();
+
+-- +migrate Down
+
+drop trigger if exists handle_knowledge_updated_at on public.knowledge;
+drop function if exists public.handle_knowledge_updated_at;
+drop policy if exists "Enable update for authenticated users" on public.knowledge;
+drop policy if exists "Enable insert for authenticated users" on public.knowledge;
+drop policy if exists "Enable read access for all users" on public.knowledge;
+drop table if exists public.knowledge;


### PR DESCRIPTION
## Summary
- define `tasks` table migration with RLS policies, indexes and trigger
- define `knowledge` table migration with pgvector indexes and RLS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_openai')*

------
https://chatgpt.com/codex/tasks/task_e_685d919b4db08321b46bc7e5c05d56b8