### PR TITLE
Configure CI coverage for all agents

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+[run]
+source =
+    agents
+    orchestration
+    registry_service
+omit =
+    */tests/*
+
+[report]
+show_missing = True

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,20 @@ jobs:
           pip install -r meepzorp/requirements.txt
           pip install pytest pytest-asyncio
 
-      - name: Run tests
-        run: pytest meepzorp/orchestration/tests -q --cov=meepzorp --cov-fail-under=80
+      - name: Run agent tests
+        run: |
+          COVERAGE_FILE=.coverage.agents \
+          pytest meepzorp/agents/*/tests meepzorp/agents/*/*/tests -q --cov=agents
+
+      - name: Run service tests
+        run: |
+          COVERAGE_FILE=.coverage.services \
+          pytest meepzorp/orchestration/tests meepzorp/registry_service/tests -q --cov=orchestration --cov=registry_service
+
+      - name: Combine coverage
+        run: |
+          coverage combine
+          coverage report --fail-under=80
 
       - name: Build Docker images (no push)
         run: |


### PR DESCRIPTION
## Summary
- execute agent and service tests in CI
- combine coverage reports
- enforce 80% coverage threshold
- track packages for coverage in `.coveragerc`

## Testing
- `pytest agents/*/tests agents/*/*/tests -q` *(fails: ModuleNotFoundError)*
- `pytest orchestration/tests registry_service/tests -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685d919fcf8c8321a5518c0c8d53cab0