### PR TITLE
Implement JWT verification for get_current_user

### DIFF
--- a/agents/common/auth.py
+++ b/agents/common/auth.py
@@ -1,26 +1,33 @@
 """
 Authentication module for MCP agents.
 
-This module provides common authentication functionality using FastAPI's OAuth2 scheme.
-Currently implements a simplified version that uses the token as the user ID.
-Future improvements could include JWT validation, role-based access, etc.
+This module provides authentication utilities for FastAPI agents using
+JWT-based Bearer tokens. Tokens are validated and decoded to determine
+the current user.
 """
 
-from typing import Annotated, Optional
+from typing import Annotated
 
+import os
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
 
 # Initialize OAuth2 scheme with token URL
 # Note: This URL is just a placeholder - tokens are not actually issued here
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 
+# JWT configuration
+JWT_SECRET = os.getenv("JWT_SECRET", "secret")
+ALGORITHM = os.getenv("JWT_ALGORITHM", "HS256")
+
 async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]) -> str:
     """
     Dependency that extracts and validates the current user from the OAuth2 token.
     
-    Currently implements a simplified version that returns the token as the user ID.
-    Future improvements could include proper JWT validation, user lookup, etc.
+    Decodes and verifies a JWT token to extract the user ID.  The token is
+    expected to contain a ``sub`` claim identifying the user.  Tokens are
+    validated using the ``JWT_SECRET`` and ``ALGORITHM`` defined above.
     
     Args:
         token: The OAuth2 token from the request
@@ -37,7 +44,16 @@ async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]) -> str
             detail="Could not validate credentials",
             headers={"WWW-Authenticate": "Bearer"},
         )
-    
-    # TODO: Add proper token validation and user lookup
-    # For now, just return the token as the user ID
-    return token 
+
+    try:
+        payload = jwt.decode(token, JWT_SECRET, algorithms=[ALGORITHM])
+        user_id: str | None = payload.get("sub") or payload.get("user_id")
+        if not user_id:
+            raise JWTError("Missing subject")
+        return user_id
+    except JWTError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )

--- a/agents/common/tests/test_auth.py
+++ b/agents/common/tests/test_auth.py
@@ -1,0 +1,27 @@
+import pytest
+from jose import jwt
+from fastapi import HTTPException
+
+from agents.common import auth
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_valid():
+    token = jwt.encode({"sub": "alice"}, auth.JWT_SECRET, algorithm=auth.ALGORITHM)
+    user = await auth.get_current_user(token)
+    assert user == "alice"
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_invalid_signature():
+    bad_token = jwt.encode({"sub": "alice"}, "wrong", algorithm=auth.ALGORITHM)
+    with pytest.raises(HTTPException) as exc:
+        await auth.get_current_user(bad_token)
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_missing_token():
+    with pytest.raises(HTTPException) as exc:
+        await auth.get_current_user("")
+    assert exc.value.status_code == 401


### PR DESCRIPTION
## Summary
- decode JWT tokens in `get_current_user`
- add config for JWT secret and algorithm
- raise `HTTPException` when tokens fail validation
- test token handling logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jose')*

------
https://chatgpt.com/codex/tasks/task_e_685d91a63b408321994466830ca0bba2